### PR TITLE
Prepare for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.6] - (unreleased)
+## [0.8.0] - (2025.12.07)
 - Add support to jit precompiled native code sections (`avmN`)
+- Add support for type (`Type`) code sections for native code optimizations
+- Start module is set from `--start`, if present, or determined by the module exporting `start/0`
+- Add `--lib` option for packing libraries without setting a start module
 
 ## [0.7.5] - (2025.08.18)
 
@@ -60,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed the `packbeam_api:create` function to take a single map for optional
-parameters, instead of coding paramters into function arguments.  Previous
+parameters, instead of coding parameters into function arguments.  Previous
 versions of the `packbeam_api:create` function that take optional parameters
 have been deprecated.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please, also make sure to understand the [Apache 2.0 license](LICENSE) and the
 Last but not least, **do not use GitHub issues for vulnerability reports**, read instead the
 [security policy](SECURITY.md) for instructions.
 
-## Git Recommended Practises
+## Git Recommended Practices
 
 * Commit messages should have a
 * [summary and a description](https://github.com/erlang/otp/wiki/writing-good-commit-messages)
@@ -27,48 +27,10 @@ Last but not least, **do not use GitHub issues for vulnerability reports**, read
 
 ## Coding Style
 
-### C Code
+### Erlang Code
 
-#### Identation
+Format with `erlfmt` enforced style:
 
-* [K&R identation and braces style](https://en.wikipedia.org/wiki/Indentation_style#K&R_style)
-* [Mandatory braces](https://en.wikipedia.org/wiki/Indentation_style#Variant:_mandatory_braces)
-* 4 spaces identation
-
-Good:
+```shell
+    $ rebar3 fmt
 ```
-void f(int reverse)
-{
-    if (reverse) {
-        puts("!dlroW olleH");
-    } else {
-        puts("Hello world");
-    }
-}
-```
-
-Bad:
-```
-void f(int reverse) {
-    if (reverse)
-        puts ("!dlroW olleH");
-    else
-        puts ("Hello world");
-}
-```
-
-#### Names
-
-* Struct names are PascalCase (e.g. Context)
-* Scalar types are lower case (e.g. term)
-* All other names (e.g. functions and variables) are snake_case (e.g. term_is_integer)
-* Always prefix function names (e.g. term_is_nil, term_is_integer, context_new, context_destroy)
-
-#### Other Coding Conventions
-* Pointer * should be with the variable name rather than with the type (e.g. `char *name`, not
-`char* name`)
-* Avoid long lines, use intermediate variables with meaningful names.
-
-### Elixir Code
-
-Just use Elixir formatter enforced style.

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ rel:
 	rebar3 as prod tar
 	rm -rf x
 	mkdir x
-	./install.sh x 0.7.5
+	./install.sh x 0.8.0
 	x/bin/packbeam version
 
 clean:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build a release, run the following commands:
 These commands will create an Erlang tar archive containing a versioned release of the `atomvm_packbeam` tool, e.g.,
 
     ...
-    ===> Tarball successfully created: _build/prod/rel/atomvm_packbeam/atomvm_packbeam-0.7.5.tar.gz
+    ===> Tarball successfully created: _build/prod/rel/atomvm_packbeam/atomvm_packbeam-0.8.0.tar.gz
 
 in your local working directory.
 
@@ -42,8 +42,8 @@ in your local working directory.
 
 You can use the `install.sh` script to install the `atomvm_packbeam` utility into a location on your local machine.  You will need to specify the prefix location into which you want to install the utility, together with it's current version.
 
-    shell$ ./install.sh /opt/atomvm_packbeam 0.7.5
-    atomvm_packbeam version 0.7.5 installed in /opt/atomvm_packbeam.
+    shell$ ./install.sh /opt/atomvm_packbeam 0.8.0
+    atomvm_packbeam version 0.8.0 installed in /opt/atomvm_packbeam.
 
 > Note.  Some prefix locations may require `root` permissions to write files to.
 
@@ -69,7 +69,7 @@ On-line help is available via the `help` sub-command:
 
     shell$ packbeam help
 
-    packbeam version 0.7.5
+    packbeam version 0.8.0
 
     Syntax:
         packbeam <sub-command> <options> <args>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,8 @@ expected to receive security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.7.x   | :white_check_mark: |
+| 0.8.x   | :white_check_mark: |
+| 0.7.x   | :x:                |
 | 0.6.x   | :x:                |
 | < 0.6   | :x:                |
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -6,6 +6,12 @@
 
 # AtomVM Update Instructions
 
+## 0.7.* -> 0.8.*
+
+- No changes have been made to default behaviors that should affect any existing applications that
+depend on `atomvm_packbeam` or its escript usage. New options have been added, consult the
+documentation for details.
+
 ## 0.6.* -> 0.7.*
 
 - The default behavior of not generating line number information in BEAM files has changed.  By default, line number information will be generated in BEAM files.  You can remove line number information using from BEAM files by using the `-r` (or `--remove_lines`) flags to the `create` subcommand.  Note that in versions 0.6 of this tool, the `--include_lines` flag was ignored due to a bug in the code.

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,7 @@
 ]}.
 
 {relx, [
-    {release, {atomvm_packbeam, "0.7.5"}, [
+    {release, {atomvm_packbeam, "0.8.0"}, [
         kernel,
         stdlib,
         atomvm_packbeam
@@ -69,5 +69,6 @@
 
 %% copy the generated escript into the release
 {post_hooks, [
-    {release, "cp ${REBAR_BUILD_DIR}/bin/packbeam ${REBAR_BUILD_DIR}/rel/atomvm_packbeam/bin/packbeam"}
+    {release,
+        "cp ${REBAR_BUILD_DIR}/bin/packbeam ${REBAR_BUILD_DIR}/rel/atomvm_packbeam/bin/packbeam"}
 ]}.

--- a/src/atomvm_packbeam.app.src
+++ b/src/atomvm_packbeam.app.src
@@ -22,7 +22,7 @@
     [
         {description,
             "An escript and library to manipulate (create, list, delete) AtomVM PackBeam files"},
-        {vsn, "0.7.5"},
+        {vsn, "0.8.0"},
         {registered, []},
         {applications, [kernel, stdlib]},
         {env, []},

--- a/src/packbeam_api.erl
+++ b/src/packbeam_api.erl
@@ -148,7 +148,8 @@ create(OutputPath, InputPaths, Options) ->
 %%          will occur first in the generated AVM file.
 %% @returns ok if the file was created.
 %% @throws  Reason::string()
-%% @deprecated This function is deprecated.  Use `create/3' instead.
+%% @deprecated This function is deprecated, and will be removed in the 0.9.0 release.  Use
+%% `create/3' instead.
 %% @doc     Create an AVM file.
 %%
 %%          Equivalent to create(OutputPath, InputPaths, undefined, Prune, StartModule).
@@ -163,7 +164,9 @@ create(OutputPath, InputPaths, Options) ->
 ) ->
     ok | {error, Reason :: term()}.
 create(OutputPath, InputPaths, Prune, StartModule) ->
-    io:format("WARNING: Deprecated function: ~p:create/4~n", [?MODULE]),
+    io:format("WARNING: Deprecated function will be removed in the 0.9.0 release: ~p:create/4~n", [
+        ?MODULE
+    ]),
     Options = #{prune => Prune, start_module => StartModule},
     create(OutputPath, InputPaths, maps:merge(?DEFAULT_OPTIONS, Options)).
 
@@ -182,7 +185,8 @@ create(OutputPath, InputPaths, Prune, StartModule) ->
 %%          will occur first in the generated AVM file.
 %% @returns ok if the file was created.
 %% @throws  Reason::string()
-%% @deprecated This function is deprecated.  Use `create/3' instead.
+%% @deprecated This function is deprecated, and will be removed in the 0.9.0 release.  Use
+%% `create/3' instead.
 %% @doc     Create an AVM file.
 %%
 %%          This function will create an AVM file at the location specified in
@@ -199,7 +203,9 @@ create(OutputPath, InputPaths, Prune, StartModule) ->
 ) ->
     ok | {error, Reason :: term()}.
 create(OutputPath, InputPaths, ApplicationModule, Prune, StartModule) ->
-    io:format("WARNING: Deprecated function: ~p:create/5~n", [?MODULE]),
+    io:format("WARNING: Deprecated function will be removed in the 0.9.0 release: ~p:create/5~n", [
+        ?MODULE
+    ]),
     Options = #{
         prune => Prune, start_module => StartModule, application_module => ApplicationModule
     },


### PR DESCRIPTION
Bump minor release version number in honor of added precompiled jit support, and enabling the packing of applications into AtomVM escripts, as well as enabling the packing of libraries, which is needed to adopt this version of `packbeam` as the one used throughout the AtomVM infrastructure.

Cleans up the Contributing guidelines, removing the non-aplicable C code style refrences.