### PR TITLE
Fix dialyzer & add workflow

### DIFF
--- a/.github/workflows/dialyzer.yaml
+++ b/.github/workflows/dialyzer.yaml
@@ -1,0 +1,45 @@
+#
+#  Copyright 2025 Peter M <petermm@gmail.com>
+#
+#  SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+#
+# This is a workflow for atomvm/atomvm_packbeam to check Dialyzer
+
+name: Dialyzer
+
+on:
+  push:
+    paths:
+      - "src/**"
+      - "rebar.config"
+  pull_request:
+    paths:
+      - "src/**"
+      - "rebar.config"
+
+jobs:
+  dialyzer:
+    runs-on: ubuntu-24.04
+    container: erlang:${{ matrix.otp }}
+    strategy:
+      matrix:
+        otp: ["25", "26", "27", "28"]
+    permissions:
+      contents: read
+
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
+
+      - name: "Restore PLT cache"
+        uses: actions/cache@v4
+        with:
+          path: _build/default/*_plt*
+          key: plt-${{ matrix.otp }}-${{ hashFiles('rebar.config') }}
+          restore-keys: |
+            plt-${{ matrix.otp }}-
+
+      - name: "Run Dialyzer"
+        run: rebar3 dialyzer

--- a/src/packbeam.erl
+++ b/src/packbeam.erl
@@ -70,6 +70,7 @@ delete(OutputPath, InputPath, Names) ->
 %%
 
 %% @hidden
+-spec main([string()]) -> no_return().
 main(Argv) ->
     {Opts, Args} = parse_args(Argv),
     case length(Args) of

--- a/src/packbeam_api.erl
+++ b/src/packbeam_api.erl
@@ -52,6 +52,7 @@
 -type avm_element_name() :: string().
 -type options() :: #{
     prune => boolean(),
+    lib => boolean(),
     start_module => module() | undefined,
     application_module => module() | undefined,
     include_lines => boolean()


### PR DESCRIPTION
https://ampcode.com/threads/T-019c6e13-2e69-73fd-9604-0745a7e79868

All 14 dialyzer warnings are now resolved. These changes were made:

packbeam_api.erl: Added lib => boolean() to the options() type — it was used in ?DEFAULT_OPTIONS and by callers but missing from the type spec.
packbeam.erl main/1: Added -spec main([string()]) -> no_return(). since the escript entrypoint always calls erlang:halt/1.

Fixes: https://github.com/atomvm/atomvm_packbeam/issues/56