### PR TITLE
Fix prune of callback modules from AVM libs

### DIFF
--- a/test/prune_sup/my_sup.erl
+++ b/test/prune_sup/my_sup.erl
@@ -1,0 +1,18 @@
+%%
+%% Copyright (c) 2026 Peter M <petermm@gmail.com>
+%% All rights reserved.
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
+%% @doc A supervisor-like module whose init returns child specs.
+%% The child module (my_worker) is only referenced as an atom.
+-module(my_sup).
+
+-export([start_link/0, init/1]).
+
+start_link() ->
+    init([]).
+
+init(_Args) ->
+    ChildSpecs = [#{id => my_worker, start => {my_worker, start_link, []}}],
+    {ok, {#{}, ChildSpecs}}.

--- a/test/prune_sup/my_worker.erl
+++ b/test/prune_sup/my_worker.erl
@@ -1,0 +1,14 @@
+%%
+%% Copyright (c) 2026 Peter M <petermm@gmail.com>
+%% All rights reserved.
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
+%% @doc A worker module only referenced as a callback in a supervisor
+%% child spec. No module directly imports this module.
+-module(my_worker).
+
+-export([start_link/0]).
+
+start_link() ->
+    ok.

--- a/test/prune_sup/start_mod.erl
+++ b/test/prune_sup/start_mod.erl
@@ -1,0 +1,15 @@
+%%
+%% Copyright (c) 2026 Peter M <petermm@gmail.com>
+%% All rights reserved.
+%%
+%% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+
+%% @doc A start module that starts a supervisor.
+%% The supervisor module (my_sup) is referenced via atoms and imports.
+-module(start_mod).
+
+-export([start/0]).
+
+start() ->
+    Sup = my_sup,
+    Sup:start_link().


### PR DESCRIPTION
Fixes: https://github.com/atomvm/atomvm_packbeam/issues/58

https://ampcode.com/threads/T-019c6de0-ba10-7688-bedb-4ce12d207c0a

When using -p (prune) with modules sourced from a .avm library, modules referenced only in literals (e.g., supervisor callback modules in child specs) were incorrectly pruned.

The root cause was that parse_beam (the AVM parsing path) did not extract uncompressed_literals, while the .beam parsing path (parse_file(beam, ...)) did. This meant get_atoms/1 could not find atoms that only appear in the literals table — such as a worker module name inside a supervisor child spec map — when the containing module came from an .avm file.

The fix adds literal extraction to the AVM parsing path, making it consistent with the .beam path.

Test modules added (test/prune_sup/):

start_mod.erl — entrypoint that calls my_sup
my_sup.erl — supervisor-like module with my_worker only in a literal child spec (not in atoms chunk or imports) my_worker.erl — callback module, never directly imported

Tests added:

packbeam_create_prune_supervisor_callback_test — verifies pruning keeps literal-only references (all .beam inputs) packbeam_create_prune_supervisor_callback_from_avm_test — same scenario with modules from a .avm lib (was failing before the fix)