### PR TITLE
Fix publish_docs workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -28,13 +28,19 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
-    container: erlang:28
     steps:
 
     - name: "Set locale"
       run: |
           sudo locale-gen C.UTF-8
           sudo update-locale LANG="C.UTF-8"
+
+    - name: "Setup BEAM"
+      id: beam-setup
+      uses: erlef/setup-beam@v1.20.4
+      with:
+        otp-version: "28.3"
+        rebar3-version: "3.26.0"
 
     - name: "Checkout code"
       uses: actions/checkout@v5
@@ -51,7 +57,7 @@ jobs:
       uses: actions/upload-pages-artifact@v3
       with:
         name: github-pages
-        path: ./docs
+        path: ./doc
 
   deploy:
     # Add a dependency to the build job


### PR DESCRIPTION
Root privileges are needed to set the locale to UTF-8 for ex_doc, but sudo is not available in the erlang:28 container, so instead the setup-beam action is used after setting the locale.

For an example of sudo failing, see this workflow run: https://github.com/atomvm/atomvm_packbeam/actions/runs/22147359424

Fixes incorrect doc dir that was not updated in commit a08370cd873d9b6cf9c8b2f40ce2f7f8c90b56e7 (PR #53).
